### PR TITLE
Fix ID generation

### DIFF
--- a/Pages/Courier/AvailableShipments.razor
+++ b/Pages/Courier/AvailableShipments.razor
@@ -26,7 +26,7 @@
         UnassignedShipments = ShipmentService.GetUnassigned();
     }
 
-    public async Task AssignPackageToCourier(ulong shipmentId)
+    public async Task AssignPackageToCourier(long shipmentId)
     {
         var shipment = await ShipmentRepository.Shipments.FirstOrDefaultAsync(s => s.Id == shipmentId);
         if (shipment == null)

--- a/Persistence/Database/SeedData.cs
+++ b/Persistence/Database/SeedData.cs
@@ -47,7 +47,7 @@ namespace shipping_service.Persistence.Database
                 int passwordColumnPosition = sheet.GetColumnByName("Password");
                 for (int i = 2; i <= sheet.Dimension.Rows; i++)
                 {
-                    ulong id = Convert.ToUInt64(
+                    long id = Convert.ToInt64(
                         sheet.Cells[i, idColumnPosition].Value.ToString());
                     string username = sheet.Cells[i, usernameColumnPosition].Value.ToString();
                     string password = sheet.Cells[i, passwordColumnPosition].Value.ToString();
@@ -72,7 +72,7 @@ namespace shipping_service.Persistence.Database
                 int nameColumnPosition = sheet.GetColumnByName("Name");
                 for (int i = 2; i <= sheet.Dimension.Rows; i++)
                 {
-                    ulong id = Convert.ToUInt64(
+                    long id = Convert.ToInt64(
                         sheet.Cells[i, idColumnPosition].Value.ToString());
                     string username = sheet.Cells[i, usernameColumnPosition].Value.ToString();
                     string password = sheet.Cells[i, passwordColumnPosition].Value.ToString();
@@ -97,7 +97,7 @@ namespace shipping_service.Persistence.Database
                 int addressColumnPosition = sheet.GetColumnByName("Address");
                 for (int i = 2; i <= sheet.Dimension.Rows; i++)
                 {
-                    ulong id = Convert.ToUInt64(
+                    long id = Convert.ToInt64(
                         sheet.Cells[i, idColumnPosition].Value.ToString());
                     string name = sheet.Cells[i, nameColumnPosition].Value.ToString();
                     string address = sheet.Cells[i, addressColumnPosition].Value.ToString();
@@ -125,16 +125,16 @@ namespace shipping_service.Persistence.Database
                 int statusColumnPosition = sheet.GetColumnByName("Status");
                 for (int i = 2; i <= sheet.Dimension.Rows; i++)
                 {
-                    ulong id = Convert.ToUInt64(
+                    long id = Convert.ToInt64(
                         sheet.Cells[i, idColumnPosition].Value.ToString());
                     string title = sheet.Cells[i, titleColumnPosition].Value.ToString();
                     string? description = sheet.Cells[i, descriptionColumnPosition].Value?.ToString();
-                    ulong senderId = Convert.ToUInt64(
+                    long senderId = Convert.ToInt64(
                         sheet.Cells[i, senderIdColumnPosition].Value.ToString());
                     string? courierIdString = sheet.Cells[i, courierIdColumnPosition].Value?.ToString();
-                    ulong sourceMachineId = Convert.ToUInt64(
+                    long sourceMachineId = Convert.ToInt64(
                         sheet.Cells[i, sourceMachineIdColumnPosition].Value.ToString());
-                    ulong destinationMachineId = Convert.ToUInt64(
+                    long destinationMachineId = Convert.ToInt64(
                         sheet.Cells[i, destinationMachineIdColumnPosition].Value.ToString());
                     string shipmentStatusString =
                         sheet.Cells[i, statusColumnPosition].Value.ToString();
@@ -148,7 +148,7 @@ namespace shipping_service.Persistence.Database
                             Description = description,
                             Status = shipmentStatus,
                             SenderId = senderId,
-                            CourierId = courierIdString == null ? null : Convert.ToUInt64(courierIdString),
+                            CourierId = courierIdString == null ? null : Convert.ToInt64(courierIdString),
                             SourceMachineId = sourceMachineId,
                             DestinationMachineId = destinationMachineId
                         };

--- a/Persistence/Entities/Courier.cs
+++ b/Persistence/Entities/Courier.cs
@@ -5,7 +5,7 @@
         public string Username { get; set; }
         public byte[] HashedPassword { get; set; }
         public ICollection<Shipment> CurrentShipments { get; set; }
-        public ulong Id { get; set; }
+        public long Id { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
     }

--- a/Persistence/Entities/IBaseEntity.cs
+++ b/Persistence/Entities/IBaseEntity.cs
@@ -2,7 +2,7 @@ namespace shipping_service.Persistence.Entities
 {
     public interface IBaseEntity
     {
-        public ulong Id { get; set; }
+        public long Id { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
     }

--- a/Persistence/Entities/PostMachine.cs
+++ b/Persistence/Entities/PostMachine.cs
@@ -6,7 +6,7 @@
         public string Address { get; set; }
         public ICollection<Shipment> ShipmentsWithThisSource { get; set; } = new List<Shipment>();
         public ICollection<Shipment> ShipmentsWithThisDestination { get; set; } = new List<Shipment>();
-        public ulong Id { get; set; }
+        public long Id { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
     }

--- a/Persistence/Entities/Sender.cs
+++ b/Persistence/Entities/Sender.cs
@@ -5,7 +5,7 @@
         public byte[] HashedPassword { get; set; }
         public string Username { get; set; }
         public ICollection<Shipment> Shipments { get; set; } = new List<Shipment>();
-        public ulong Id { get; set; }
+        public long Id { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
     }

--- a/Persistence/Entities/Shipment.cs
+++ b/Persistence/Entities/Shipment.cs
@@ -5,15 +5,15 @@
         public string Title { get; set; }
         public string? Description { get; set; }
         public Sender Sender { get; set; }
-        public ulong SenderId { get; set; }
+        public long SenderId { get; set; }
         public Courier? Courier { get; set; }
-        public ulong? CourierId { get; set; }
+        public long? CourierId { get; set; }
         public PostMachine SourceMachine { get; set; }
-        public ulong SourceMachineId { get; set; }
+        public long SourceMachineId { get; set; }
         public PostMachine DestinationMachine { get; set; }
-        public ulong DestinationMachineId { get; set; }
+        public long DestinationMachineId { get; set; }
         public ShipmentStatus Status { get; set; }
-        public ulong Id { get; set; }
+        public long Id { get; set; }
         public DateTime Created { get; set; }
         public DateTime Modified { get; set; }
     }

--- a/Persistence/Migrations/20220429091805_change IDs to be long instead of ulong.Designer.cs
+++ b/Persistence/Migrations/20220429091805_change IDs to be long instead of ulong.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using shipping_service.Persistence.Database;
@@ -11,9 +12,10 @@ using shipping_service.Persistence.Database;
 namespace shipping_service.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20220429091805_change IDs to be long instead of ulong")]
+    partial class changeIDstobelonginsteadofulong
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Persistence/Migrations/20220429091805_change IDs to be long instead of ulong.cs
+++ b/Persistence/Migrations/20220429091805_change IDs to be long instead of ulong.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace shipping_service.Migrations
+{
+    public partial class changeIDstobelonginsteadofulong : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "SourceMachineId",
+                table: "Shipments",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "SenderId",
+                table: "Shipments",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "DestinationMachineId",
+                table: "Shipments",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "CourierId",
+                table: "Shipments",
+                type: "bigint",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "Id",
+                table: "Shipments",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "Id",
+                table: "Senders",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "Id",
+                table: "PostMachines",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "Id",
+                table: "Couriers",
+                type: "bigint",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)")
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "SourceMachineId",
+                table: "Shipments",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "SenderId",
+                table: "Shipments",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "DestinationMachineId",
+                table: "Shipments",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CourierId",
+                table: "Shipments",
+                type: "numeric(20,0)",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "bigint",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Shipments",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Senders",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "PostMachines",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Couriers",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(long),
+                oldType: "bigint")
+                .OldAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+        }
+    }
+}


### PR DESCRIPTION
PostgreSQL for some reason cannot automatically generate `ulong` values, but `long` is fine. Also this change exposes a problem: seed data has IDs which overlap the autogenerated ones, because the autogenerated values start from 1 (when you try to insert a new record into DB, it complains that ID is the same).

Fixes #10