### PR TITLE
Shipment tracking page (displaying shipment info and status)

### DIFF
--- a/Pages/Shipment/ShipmentTracking.razor
+++ b/Pages/Shipment/ShipmentTracking.razor
@@ -66,7 +66,7 @@ else
             return;
         }
 
-        if(!Regex.IsMatch(trackingLink, "^[0-9]([A-Za-z0-9]{4})$"))
+        if(!Regex.IsMatch(trackingLink, @"^[0-9]*([A-Za-z0-9-_]{4})$"))
         {
             return;
         }
@@ -84,7 +84,6 @@ else
         if(Shipment == null || !Shipment.IsValidIdHash(trackingCode))
         {
             Shipment = null;
-            return;
         }
     }
 }

--- a/Pages/Shipment/ShipmentTracking.razor
+++ b/Pages/Shipment/ShipmentTracking.razor
@@ -65,23 +65,21 @@ else
         {
             return;
         }
-
-        if(!Regex.IsMatch(trackingLink, @"^[0-9]*([A-Za-z0-9-_]{4})$"))
+        long shipmentId;
+        string[] trackingLinkParts = trackingLink.Split("-");
+        string trackingCode = string.Join("-", trackingLinkParts.Skip(1));
+        if (!Regex.IsMatch(trackingCode, @"^([A-Za-z0-9-_]{4})$") ||
+            !long.TryParse(trackingLinkParts[0], out shipmentId))
         {
             return;
         }
-
-        long shipmentId = trackingLink[0] - '0';
-        string trackingCode = trackingLink.Substring(1, trackingLink.Length-1);
-
         Shipment = ShipmentRepository.Shipments.
             Include(s => s.Sender).
             Include(s => s.Courier).
             Include(s => s.SourceMachine).
             Include(s => s.DestinationMachine).
             FirstOrDefault(s => s.Id == shipmentId);
-
-        if(Shipment == null || !Shipment.IsValidIdHash(trackingCode))
+        if(Shipment != null && !Shipment.IsValidIdHash(trackingCode))
         {
             Shipment = null;
         }

--- a/Pages/Shipment/ShipmentTracking.razor
+++ b/Pages/Shipment/ShipmentTracking.razor
@@ -1,0 +1,72 @@
+﻿@page "/shipment/tracking/{trackingLink}"
+@inject NavigationManager NavigationManager
+
+<h3>Shipment Tracking</h3>
+@if (Shipment != null)
+{
+    <div class="parcel-info">
+        <h2>Parcel information</h2>
+
+        <label class="title">Sender</label><br/>
+        <label>@Shipment.Sender.Username</label><br/>
+
+        <label class="title">Shipment title</label><br/>
+        <label>@Shipment.Title</label><br/>
+
+        <label class="title">Description</label><br/>
+        <label>@(Shipment.Description ?? "No description provided.")</label><br/>
+
+        <label class="title">Shipment registration date</label><br/>
+        <label>@Shipment.Created</label><br/>
+    </div>
+    <div class="shipment-info">
+        <div>
+            <h2>Shipment information</h2>
+
+            <label class="title">Assigned courier</label><br/>
+            <label>@(Shipment.Courier?.Username ?? "No courier has promised to deliver this shipment yet.")</label><br/>
+
+            <label class="title">Source post machine address</label><br/>
+            <label>@Shipment.SourceMachine.Address</label><br/>
+
+            <label class="title">Destination post machine address</label><br/>
+            <label>@Shipment.DestinationMachine.Address</label><br/>
+        </div>
+        <div class="shipment-status">
+            <h2>Shipment status</h2>
+
+            <label class="title">Shipment status</label><br/>
+            <label>@Shipment.Status</label><br/>
+
+            <label class="title">Shipment status update date</label><br/>
+            <label>@Shipment.Modified</label>
+        </div>
+    </div>
+    
+}
+
+@code {
+    [Parameter]
+    public string? trackingLink { get; set; }
+
+    [Inject]
+    public IShipmentRepository ShipmentRepository { get; set; }
+
+    public Shipment? Shipment{ get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        Shipment = ShipmentRepository.Shipments.
+            Include(s => s.Sender).
+            Include(s => s.Courier).
+            Include(s => s.SourceMachine).
+            Include(s => s.DestinationMachine).
+            AsEnumerable().FirstOrDefault(s => s.IsValidIdHash(trackingLink));
+
+        if(Shipment == null)
+        {
+            NavigationManager.NavigateTo("/shipment/tracking-not-found");
+        }
+       
+    }
+}

--- a/Pages/Shipment/ShipmentTracking.razor
+++ b/Pages/Shipment/ShipmentTracking.razor
@@ -1,4 +1,6 @@
-﻿@page "/shipment/tracking/{trackingLink}"
+﻿@using System.Text.RegularExpressions
+
+@page "/shipment/tracking/{trackingLink}"
 @inject NavigationManager NavigationManager
 
 <h3>Shipment Tracking</h3>
@@ -42,7 +44,10 @@
             <label>@Shipment.Modified</label>
         </div>
     </div>
-    
+}
+else
+{
+    <label>Shipment with provided tracking link does not exist</label>
 }
 
 @code {
@@ -56,17 +61,30 @@
 
     protected override async Task OnInitializedAsync()
     {
+        if (string.IsNullOrEmpty(trackingLink))
+        {
+            return;
+        }
+
+        if(!Regex.IsMatch(trackingLink, "^[0-9]([A-Za-z0-9]{4})$"))
+        {
+            return;
+        }
+
+        long shipmentId = trackingLink[0] - '0';
+        string trackingCode = trackingLink.Substring(1, trackingLink.Length-1);
+
         Shipment = ShipmentRepository.Shipments.
             Include(s => s.Sender).
             Include(s => s.Courier).
             Include(s => s.SourceMachine).
             Include(s => s.DestinationMachine).
-            AsEnumerable().FirstOrDefault(s => s.IsValidIdHash(trackingLink));
+            FirstOrDefault(s => s.Id == shipmentId);
 
-        if(Shipment == null)
+        if(Shipment == null || !Shipment.IsValidIdHash(trackingCode))
         {
-            NavigationManager.NavigateTo("/shipment/tracking-not-found");
+            Shipment = null;
+            return;
         }
-       
     }
 }

--- a/Pages/Shipment/ShipmentTracking.razor.css
+++ b/Pages/Shipment/ShipmentTracking.razor.css
@@ -1,0 +1,21 @@
+﻿.parcel-info, .shipment-info {
+    width: 50%;
+    float: left;
+    padding: 20px;
+    height: 600px;
+    border: 2px solid black;
+}
+
+.shipment-status {
+    border-top: 2px solid black;
+}
+
+label{
+    padding: 10px
+}
+
+.title {
+    font-weight: bold;
+}
+
+

--- a/Pages/Shipment/ShipmentTrackingNotFound.razor
+++ b/Pages/Shipment/ShipmentTrackingNotFound.razor
@@ -1,0 +1,9 @@
+﻿@page "/shipment/tracking-not-found"
+
+<h3>Shipment not found</h3>
+<label>Shipment with provided tracking link does not exist</label>
+
+
+@code {
+    
+}


### PR DESCRIPTION
Created a page where shipment info is displayed. 

To reach the page, you should write /shipment/tracking/{trackingLink}.

Before loading the page, each shipment is iterated over and it's hash is compared with the tracking link. If they match, that means this is the shipment we were looking for. If nothing is found, user is redirected to a page, which says that the shipment doesn't exist.

Some available values for trackingLink (can't use registration to get the tracking link yet, so you have to use these):
QUIP
QkIP
Q0IP
REIP
RUIP
RkIP
R0IP
SEIP
SUIP
SkIP